### PR TITLE
Move artist item after language links

### DIFF
--- a/index.html
+++ b/index.html
@@ -431,15 +431,15 @@ To my wife Misa, thank you for walking this life with me.”</span>
   </div>
   <!-- ハンバーガーメニューのドロップダウン -->
   <div id="hamburger-menu">
-    <!-- メニュー項目の順番：about, exhibition, Soup, artist, その下に言語切替リンク群 -->
+    <!-- メニュー項目の順番：about, exhibition, Soup, 言語切替リンク群, artist -->
     <div class="menu-item" data-target="about">about</div>
     <div class="menu-item" data-target="exhibition">exhibition</div>
     <div class="menu-item" data-target="soup">Soup</div>
-    <div class="menu-item" data-target="artist">artist</div>
     <div class="lang-container">
       <div class="menu-item lang active" data-lang="en">EN</div>
       <div class="menu-item lang" data-lang="de">DE</div>
     </div>
+    <div class="menu-item" data-target="artist">artist</div>
   </div>
   
   <!-- #tap-hint -->


### PR DESCRIPTION
## Summary
- adjust order of hamburger menu items so language links come before the artist item
- update the explanatory comment to match

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886415901848325a39148b6b0cf20f0