### PR TITLE
Fix tap hint on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,6 +273,10 @@
       #scroll-container {
         padding-bottom: 15vh;
       }
+      #tap-hint {
+        top: auto;
+        bottom: 10vh;
+      }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- keep the hint text visible on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a35cd9a788325a7b5d8ba1b8a0607