### PR TITLE
Prevent mobile title break

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,13 +41,13 @@
       height: 120vh;
     }
     .hero-title {
-      font-size: 3rem;
+      font-size: clamp(2rem, 10vw, 3rem);
       margin: 1.5rem auto 0;
       text-align: center;
       opacity: 0;
       transform: translateY(20px);
       transition: opacity 3s ease, transform 3s ease;
-      max-width: 80%;
+      white-space: nowrap;
     }
     .hero-title.show {
       opacity: 1;


### PR DESCRIPTION
## Summary
- keep `Soup of Voice` title on one line
- make hero title responsive with CSS clamp

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bbe664644832597492322982e9563