### PR TITLE
Fix mobile tap-hint width

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,6 +276,13 @@
       #tap-hint {
         top: auto;
         bottom: 10vh;
+        width: 90vw;
+        left: 50%;
+        transform: translateX(-50%);
+      }
+      #tap-hint .primary,
+      #tap-hint .desc {
+        max-width: none;
       }
     }
   </style>


### PR DESCRIPTION
## Summary
- adjust `#tap-hint` styles for narrow screens so the text expands across the viewport

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bc0f113b4832582b0fb3414b0655f