### PR TITLE
Rename artist menu entry to Home

### DIFF
--- a/artist.html
+++ b/artist.html
@@ -138,7 +138,7 @@
     <div></div>
   </div>
   <div id="hamburger-menu">
-    <div class="menu-item" data-target="artist">artist</div>
+    <div class="menu-item" data-target="home">Home</div>
     <div class="menu-item" data-target="about">about</div>
     <div class="menu-item" data-target="exhibition">exhibition</div>
     <div class="menu-item" data-target="soup">Soup</div>
@@ -162,10 +162,6 @@
     menuItems.forEach(item => {
       item.addEventListener('click', () => {
         hamburgerMenu.classList.remove('visible');
-        const target = item.getAttribute('data-target');
-        if (target === 'artist') {
-          return;
-        }
         window.location.href = 'index.html';
       });
     });


### PR DESCRIPTION
## Summary
- Rename artist menu item to Home
- Ensure all menu selections on artist page navigate to the top page

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a8b76ef108325bbb4ba6087740b7c